### PR TITLE
modules/helix: init

### DIFF
--- a/modules/helix/check.nix
+++ b/modules/helix/check.nix
@@ -1,0 +1,20 @@
+{
+  pkgs,
+  self,
+}:
+
+let
+  helixWrapped = self.wrapperModules.helix.apply {
+    inherit pkgs;
+  };
+
+in
+pkgs.runCommand "helix-test" { } ''
+  # if the config is invalid the text helix will complain here.
+  # sady no other dedicated check config command exists
+  res=$("${helixWrapped}/bin/hx" --health | grep "malformed" || true)
+  echo $res
+  if [[ ''${#res} == 0 ]]; then
+    touch $out
+  fi
+''

--- a/modules/helix/module.nix
+++ b/modules/helix/module.nix
@@ -1,0 +1,107 @@
+{
+  wlib,
+  lib,
+  ...
+}:
+wlib.wrapModule (
+  { config, wlib, ... }:
+  let
+    tomlFmt = config.pkgs.formats.toml { };
+    conf =
+      let
+        base = tomlFmt.generate "helix-config" config.settings;
+      in
+      if config.extraSettings != "" then
+        config.pkgs.concatText "helix-config" [
+          base
+          (config.pkgs.writeText "extraSettings" config.extraSettings)
+        ]
+      else
+        base;
+    langs = tomlFmt.generate "helix-languages-config" config.languages;
+    ignore = config.pkgs.writeText "helix-ignore" (lib.strings.concatLines config.ignores);
+    themes = lib.mapAttrsToList (
+      name: value:
+      let
+        fname = "helix-theme-${name}";
+      in
+      {
+        name = "themes/${name}.toml";
+        path =
+          if lib.isString value then config.pkgs.writeText fname value else (tomlFmt.generate fname value);
+      }
+    ) config.themes;
+  in
+  {
+    options = {
+      settings = lib.mkOption {
+        type = tomlFmt.type;
+        description = ''
+          General settings
+          See <https://docs.helix-editor.com/configuration.html> 
+        '';
+        default = { };
+      };
+      extraSettings = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Extra lines appended to the config file.
+          This can be used to maintain order for settings.
+        '';
+      };
+      languages = lib.mkOption {
+        type = tomlFmt.type;
+        description = ''
+          Language specific settings
+          See <https://docs.helix-editor.com/languages.html>
+        '';
+        default = { };
+      };
+      themes = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.oneOf [
+            tomlFmt.type
+            lib.types.lines
+          ]
+        );
+        description = ''
+          Themes to add to config.
+          See <https://docs.helix-editor.com/themes.html>
+        '';
+        default = { };
+      };
+      ignores = lib.mkOption {
+        type = lib.types.listOf lib.types.nonEmptyStr;
+        default = [ ];
+        description = ''
+          List of paths to be ignored by the file-picker.
+          The format is the same as in .gitignore.
+        '';
+      };
+    };
+    config.package = lib.mkDefault config.pkgs.helix;
+    config.env = {
+      XDG_CONFIG_HOME = builtins.toString (
+        config.pkgs.linkFarm "helix-merged-config" (
+          map
+            (a: {
+              inherit (a) path;
+              name = "helix/" + a.name;
+            })
+            (
+              let
+                entry = name: path: { inherit name path; };
+              in
+              [
+                (entry "config.toml" conf)
+                (entry "languages.toml" langs)
+                (entry "ignore" ignore)
+              ]
+              ++ themes
+            )
+        )
+      );
+    };
+  }
+)


### PR DESCRIPTION
finally got around to write a module for helix.
its basically a drop-in replacement for the home-manager module for it (minus being able to set it as the default editor, which is to be expected).