### PR TITLE
modules/alacritty: init

### DIFF
--- a/modules/alacritty/module.nix
+++ b/modules/alacritty/module.nix
@@ -1,0 +1,33 @@
+{
+  wlib,
+  lib,
+  ...
+}:
+wlib.wrapModule (
+  { config, wlib, ... }:
+  let
+    tomlFmt = config.pkgs.formats.toml { };
+  in
+  {
+    options = {
+      settings = lib.mkOption {
+        type = tomlFmt.type;
+        default = { };
+        description = ''
+          Configuration of alacritty.
+          See {manpage}`alacritty(5)` or <https://alacritty.org/config-alacritty.html>
+        '';
+      };
+      extraFlags = lib.mkOption {
+        type = lib.types.attrsOf lib.types.unspecified; # TODO add list handling
+        default = { };
+        description = "Extra flags to pass to alacritty.";
+      };
+    };
+    config.flags = {
+      "--config-file" = tomlFmt.generate "alacritty.toml" config.settings;
+    }
+    // config.extraFlags;
+    config.package = lib.mkDefault config.pkgs.alacritty;
+  }
+)


### PR DESCRIPTION
yet another very simple module. maybe i should add a helper to wlib that just takes the config format and flag/env var.
its also not really possible to write a useful test unless its run in a graphical environment.