### PR TITLE
wrapModule: add meta.${maintainers,platforms}

### DIFF
--- a/checks/meta-maintainers.nix
+++ b/checks/meta-maintainers.nix
@@ -1,0 +1,56 @@
+{
+  pkgs,
+  self,
+}:
+
+let
+  # Test with a nixpkgs maintainer (lassulus)
+  nixpkgsMaintainer = pkgs.lib.maintainers.lassulus;
+
+  helloModule = self.lib.wrapModule (
+    { config, ... }:
+    {
+      config.package = config.pkgs.hello;
+      config.meta.maintainers = [ nixpkgsMaintainer ];
+    }
+  );
+
+  moduleConfig = helloModule.apply { inherit pkgs; };
+
+in
+pkgs.runCommand "meta-maintainers-test" { } ''
+  echo "Testing meta.maintainers field with nixpkgs maintainer..."
+
+  # Check that meta.maintainers is set correctly
+  maintainers='${builtins.toJSON moduleConfig.meta.maintainers}'
+  echo "Maintainers: $maintainers"
+
+  # Verify the maintainer has all required fields
+  if ! echo "$maintainers" | grep -q "Lassulus"; then
+    echo "FAIL: name 'Lassulus' not found in maintainers"
+    exit 1
+  fi
+
+  if ! echo "$maintainers" | grep -q "lassulus@gmail.com"; then
+    echo "FAIL: email 'lassulus@gmail.com' not found in maintainers"
+    exit 1
+  fi
+
+  if ! echo "$maintainers" | grep -q '"github":"Lassulus"'; then
+    echo "FAIL: github 'Lassulus' not found in maintainers"
+    exit 1
+  fi
+
+  if ! echo "$maintainers" | grep -q '"githubId":621759'; then
+    echo "FAIL: githubId '621759' not found in maintainers"
+    exit 1
+  fi
+
+  if ! echo "$maintainers" | grep -q '@lassulus:lassul.us'; then
+    echo "FAIL: matrix '@lassulus:lassul.us' not found in maintainers"
+    exit 1
+  fi
+
+  echo "SUCCESS: meta.maintainers test passed with nixpkgs maintainer"
+  touch $out
+''

--- a/checks/meta-platforms.nix
+++ b/checks/meta-platforms.nix
@@ -1,0 +1,110 @@
+{
+  pkgs,
+  self,
+}:
+
+let
+  # Test 1: Default platforms (should be lib.platforms.all)
+  helloModuleDefault = self.lib.wrapModule (
+    { config, ... }:
+    {
+      config.package = config.pkgs.hello;
+    }
+  );
+
+  moduleConfigDefault = helloModuleDefault.apply { inherit pkgs; };
+
+  # Test 2: Custom platforms (linux only)
+  helloModuleLinux = self.lib.wrapModule (
+    { config, ... }:
+    {
+      config.package = config.pkgs.hello;
+      config.meta.platforms = pkgs.lib.platforms.linux;
+    }
+  );
+
+  moduleConfigLinux = helloModuleLinux.apply { inherit pkgs; };
+
+  # Test 3: Specific platforms list
+  helloModuleSpecific = self.lib.wrapModule (
+    { config, ... }:
+    {
+      config.package = config.pkgs.hello;
+      config.meta.platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    }
+  );
+
+  moduleConfigSpecific = helloModuleSpecific.apply { inherit pkgs; };
+
+in
+pkgs.runCommand "meta-platforms-test" { } ''
+  echo "Testing meta.platforms field..."
+
+  # Test 1: Check default platforms
+  defaultPlatforms='${builtins.toJSON moduleConfigDefault.meta.platforms}'
+  echo "Default platforms: $defaultPlatforms"
+
+  if [ "$defaultPlatforms" = "[]" ]; then
+    echo "FAIL: Default platforms should not be empty"
+    exit 1
+  fi
+
+  # Check that default includes common platforms
+  if ! echo "$defaultPlatforms" | grep -q "x86_64-linux"; then
+    echo "FAIL: Default platforms should include x86_64-linux"
+    exit 1
+  fi
+
+  # Test 2: Check Linux-only platforms
+  linuxPlatforms='${builtins.toJSON moduleConfigLinux.meta.platforms}'
+  echo "Linux platforms: $linuxPlatforms"
+
+  if ! echo "$linuxPlatforms" | grep -q "x86_64-linux"; then
+    echo "FAIL: Linux platforms should include x86_64-linux"
+    exit 1
+  fi
+
+  if ! echo "$linuxPlatforms" | grep -q "aarch64-linux"; then
+    echo "FAIL: Linux platforms should include aarch64-linux"
+    exit 1
+  fi
+
+  # Should not include darwin when set to linux only
+  if echo "$linuxPlatforms" | grep -q "darwin"; then
+    echo "FAIL: Linux platforms should not include darwin"
+    exit 1
+  fi
+
+  # Test 3: Check specific platforms list
+  specificPlatforms='${builtins.toJSON moduleConfigSpecific.meta.platforms}'
+  echo "Specific platforms: $specificPlatforms"
+
+  if ! echo "$specificPlatforms" | grep -q "x86_64-linux"; then
+    echo "FAIL: Specific platforms should include x86_64-linux"
+    exit 1
+  fi
+
+  if ! echo "$specificPlatforms" | grep -q "aarch64-linux"; then
+    echo "FAIL: Specific platforms should include aarch64-linux"
+    exit 1
+  fi
+
+  # Should only have the two platforms we specified
+  platformCount=$(echo "$specificPlatforms" | grep -o 'linux' | wc -l | tr -d ' ')
+  if [ "$platformCount" != "2" ]; then
+    echo "FAIL: Specific platforms should have exactly 2 platforms, got $platformCount"
+    exit 1
+  fi
+
+  # Verify it doesn't contain other platforms
+  if echo "$specificPlatforms" | grep -q "darwin"; then
+    echo "FAIL: Specific platforms should not include darwin"
+    exit 1
+  fi
+
+  echo "SUCCESS: meta.platforms test passed"
+  touch $out
+''

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,7 @@
   outputs =
     { self, nixpkgs }:
     let
-      systems = [
-        "x86_64-linux"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
-      ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+      forAllSystems = f: nixpkgs.lib.genAttrs nixpkgs.lib.platforms.all (system: f system);
     in
     {
       lib = import ./lib.nix { lib = nixpkgs.lib; };
@@ -45,8 +39,10 @@
             name: type:
             let
               checkPath = ./modules + "/${name}/check.nix";
+              # Check if current system is in the module's supported platforms
+              isSupported = builtins.elem system self.wrapperModules.${name}.meta.platforms;
             in
-            if type == "directory" && builtins.pathExists checkPath then
+            if type == "directory" && builtins.pathExists checkPath && isSupported then
               {
                 name = "module-${name}";
                 value = import checkPath {

--- a/lib.nix
+++ b/lib.nix
@@ -236,6 +236,48 @@ let
                     ];
                   }).config;
               };
+              meta = {
+                maintainers = lib.mkOption {
+                  type = lib.types.listOf (
+                    lib.types.submodule (
+                      { name, ... }:
+                      {
+                        options = {
+                          name = lib.mkOption {
+                            type = lib.types.str;
+                            default = name;
+                            description = "name";
+                          };
+                          github = lib.mkOption {
+                            type = lib.types.str;
+                            description = "GitHub username";
+                          };
+                          githubId = lib.mkOption {
+                            type = lib.types.int;
+                            description = "GitHub id";
+                          };
+                          email = lib.mkOption {
+                            type = lib.types.nullOr lib.types.str;
+                            default = null;
+                            description = "email";
+                          };
+                          matrix = lib.mkOption {
+                            type = lib.types.nullOr lib.types.str;
+                            default = null;
+                            description = "Matrix ID";
+                          };
+                        };
+                      }
+                    )
+                  );
+                  default = [ ];
+                };
+                platforms = lib.mkOption {
+                  type = lib.types.listOf (lib.types.enum lib.platforms.all);
+                  default = lib.platforms.all;
+                  description = "Supported platforms";
+                };
+              };
             };
           }
         )


### PR DESCRIPTION
this somewhat mirrors what meta is doing in nixpkgs, we want to use it to disable checks on certain platforms (where the package doesn't work) or allow automerging for maintained modules later on.