### PR TITLE
modules/btop: init

### DIFF
--- a/modules/btop/check.nix
+++ b/modules/btop/check.nix
@@ -1,0 +1,24 @@
+{
+  pkgs,
+  self,
+}:
+
+let
+  btopWrapped =
+    (self.wrapperModules.btop.apply {
+      inherit pkgs;
+
+      "btop.conf".content = ''
+        color_theme = "TTY"
+        update_ms = 2000
+      '';
+
+    }).wrapper;
+
+in
+pkgs.runCommand "btop-test" { } ''
+
+  "${btopWrapped}/bin/btop" --version | grep -q "btop"
+
+  touch $out
+''

--- a/modules/btop/module.nix
+++ b/modules/btop/module.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  wlib,
+  ...
+}:
+{
+  _class = "wrapper";
+  options = {
+    "btop.conf" = lib.mkOption {
+      type = wlib.types.file config.pkgs;
+      default.content = "";
+      description = ''
+        Configuration for btop.
+      '';
+    };
+
+    extraFlags = lib.mkOption {
+      type = lib.types.attrsOf lib.types.unspecified;
+      default = { };
+      description = "Extra flags to pass to btop.";
+    };
+  };
+
+  config.flags = {
+    "--config" = config."btop.conf".path;
+  }
+  // config.extraFlags;
+
+  config.package = lib.mkDefault config.pkgs.btop;
+
+  config.meta.maintainers = [
+    {
+      name = "adeci";
+      github = "adeci";
+      githubId = 80290157;
+    }
+  ];
+  config.meta.platforms = lib.platforms.linux;
+}


### PR DESCRIPTION
module for btop

custom themes are harder to cleanly implement than I thought at first glance.
btop searches several places for themes and settles on the first location, and the first is `../share/btop/themes` for system level themes, however it does so from the context of the original bin so even with `symlinkJoin` when it looks for `../share/btop/themes`, it resolves relative to the original btop store path, not the wrapper.
The alternatives are using `XDG_CONFIG_HOME` but that feels impure?

For now this provides all other config and flags for btop, and using any of the builtin themes works.