### PR TITLE
Expose evalModule so that .options is accessible if needed

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -58,7 +58,8 @@ let
 
       # This will return a derivation that wraps the hello package with the --greeting flag set to "hi".
   */
-  wrapModule =
+  wrapModule = moduleInterface: (evalModule moduleInterface).config;
+  evalModule =
     moduleInterface:
     let
       wrapperLib = {
@@ -296,7 +297,7 @@ let
         };
       evaled = eval { };
     in
-    evaled.config;
+    evaled;
 
   /**
     Create a wrapped application that preserves all original outputs (man pages, completions, etc.)
@@ -591,5 +592,5 @@ let
     wrappedPackage;
 in
 {
-  inherit wrapModule wrapPackage;
+  inherit evalModule wrapModule wrapPackage;
 }


### PR DESCRIPTION
https://github.com/Lassulus/wrappers/pull/39

please just take 39 instead and close this one

But if you accept this first I guess I will figure out whatever git says for 39, I know git, its not an issue.

Also this is not all that is required to do docgen, just the first step, the other step is changing the module files over to just being bare modules, because currently they all call wrapModule themselves. That is a different PR, the second one I spoke of, which I will do after 39 goes through.