### PR TITLE
lib.wrapPackages: make compatible with stable nixpkgs 25.05

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -383,6 +383,9 @@ let
       ),
     }@funcArgs:
     let
+      # lndir was moved from xorg.lndir to lndir in https://github.com/NixOS/nixpkgs/pull/402102
+      lndir = if pkgs ? xorg.lndir then pkgs.xorg.lndir else pkgs.lndir;
+
       # Generate environment variable exports
       envString =
         if env == { } then
@@ -437,7 +440,7 @@ let
               # Symlink all paths to the main output
               mkdir -p $out
               for path in ${lib.concatStringsSep " " (map toString paths)}; do
-                ${pkgs.lndir}/bin/lndir -silent "$path" $out
+                ${lndir}/bin/lndir -silent "$path" $out
               done
 
               # Exclude specified files
@@ -497,7 +500,7 @@ let
                     if [[ -n "''${${output}:-}" ]]; then
                       mkdir -p ${"$" + output}
                       # Only symlink from the original package's corresponding output
-                      ${pkgs.lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${"$" + output}
+                      ${lndir}/bin/lndir -silent "${originalOutputs.${output}}" ${"$" + output}
                     fi
                   ''
                 else


### PR DESCRIPTION
lndir was under the xorg namespace prior to https://github.com/NixOS/nixpkgs/pull/402102. accept both `lndir` and `xorg.lndir` for compatibility with latest stable nixpkgs.