### PR TITLE
modules/swaylock: fix missing toString for configFile flag

### DIFF
--- a/modules/swaylock/module.nix
+++ b/modules/swaylock/module.nix
@@ -43,7 +43,7 @@ in
     };
   };
 
-  config.flags."--config" = config.configFile.path;
+  config.flags."--config" = toString config.configFile.path;
 
   config.package = config.pkgs.swaylock;
 


### PR DESCRIPTION
main is failing :cry:

looks like https://github.com/Lassulus/wrappers/pull/69 was merged without changed needed for https://github.com/Lassulus/wrappers/pull/68