### PR TITLE
Add module settings for Kitty

### DIFF
--- a/modules/kitty/check.nix
+++ b/modules/kitty/check.nix
@@ -8,9 +8,12 @@ let
     (self.wrapperModules.kitty.apply {
       inherit pkgs;
 
-      "kitty.conf".content = ''
-        font_size 12.0
-        cursor_text_color #111111
+      settings = {
+        font_size = 12;
+        cursor_text_color = "#111111";
+      };
+
+      extraSettings = ''
         cursor_shape block
       '';
     }).wrapper;

--- a/modules/kitty/module.nix
+++ b/modules/kitty/module.nix
@@ -4,15 +4,50 @@
   wlib,
   ...
 }:
+
+let
+  kittyKeyValueFormat = config.pkgs.formats.keyValue {
+    listsAsDuplicateKeys = true;
+    mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
+  };
+in
 {
   _class = "wrapper";
   options = {
-    "kitty.conf" = lib.mkOption {
-      type = wlib.types.file config.pkgs;
-      default.content = "";
+    settings = lib.mkOption {
+      type = kittyKeyValueFormat.type;
+      default = { };
       description = ''
         Configuration for kitty.
         The fast, feature-rich, GPU based terminal emulator.
+      '';
+    };
+
+    extraSettings = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        Extra lines appended to the config file.
+        This can be used to maintain order for settings.
+      '';
+    };
+
+    "kitty.conf" = lib.mkOption {
+      type = wlib.types.file config.pkgs;
+      default.path =
+        let
+          fileName = "kitty.conf";
+          base = kittyKeyValueFormat.generate fileName config.settings;
+        in
+        if config.extraSettings != "" then
+          config.pkgs.concatText fileName [
+            base
+            (config.pkgs.writeText "extraSettings" config.extraSettings)
+          ]
+        else
+          base;
+      description = ''
+        Raw configuration for kitty.
       '';
     };
   };
@@ -28,6 +63,11 @@
       name = "adeci";
       github = "adeci";
       githubId = 80290157;
+    }
+    {
+      name = "Lenny.";
+      github = "LennyPenny";
+      githubId = 4027243;
     }
   ];
   config.meta.platforms = lib.platforms.linux;


### PR DESCRIPTION
Lets you write your kitty config in nix. I tried to stay close to the helix module. Initially inspired by https://github.com/Goxore/nixconf/blob/275654fa451107662b9599a4d137f103d51a0b32/modules/wrappers/kitty.nix