### PR TITLE
modules/zsh: init

### DIFF
--- a/modules/zsh/module.nix
+++ b/modules/zsh/module.nix
@@ -8,25 +8,23 @@ wlib.wrapModule (
     cfg = config.settings;
   in {
     options = {
-      settings = {
-        keyMap = lib.mkOption {
-          type = lib.types.enum [
-            "emacs"
-            "vicmd"
-            "viins"
-          ];
-        };
-        shellAliases = lib.mkOption {
-          type = with lib.types; attrsOf str;
+      keyMap = lib.mkOption {
+        type = lib.types.enum [
+          "emacs"
+          "vicmd"
+          "viins"
+        ];
+      };
+      shellAliases = lib.mkOption {
+        type = with lib.types; attrsOf str;
 
-          description = ''
+        description = ''
 
-            aliases
+          aliases
 
-          '';
+        '';
 
-          default = {};
-        };
+        default = {};
       };
     };
 


### PR DESCRIPTION
so afaik, zsh doesn't have a flag OR envvar to set the config file. So, I resorted to setting a BUNCH of flags conditionally, not the cleanest way, but it works. This also has *almost* feature parity with the home manager module, except for external modules/apps like oh my zsh + no support for shellAliases (yet) because i couldn't figure out that flag ( it excepts a file??). 