### PR TITLE
modules/zsh: add check

### DIFF
--- a/modules/zsh/check.nix
+++ b/modules/zsh/check.nix
@@ -1,0 +1,38 @@
+{
+  pkgs,
+  self,
+}:
+let
+  zshWrapped =
+    (self.wrapperModules.zsh.apply {
+      inherit pkgs;
+      settings = {
+        keyMap = "emacs";
+        shellAliases = {
+          nvim = "nix run ~/nixos-config";
+          hdon = "hyprctl dispatch dpms on";
+          ls = "eza --icons";
+        };
+        env = {
+          NH_OS_FLAKE = "~/nixos-config";
+        };
+        history = {
+          append = true;
+          expanded = true;
+          ignoreSpace = true;
+          saveNoDups = true;
+          ignoreDups = true;
+        };
+      };
+      extraRC = ''
+        echo "test"
+        which setopt
+      '';
+    }).wrapper;
+in
+pkgs.runCommand "zsh-test" { } ''
+    "${zshWrapped}/bin/zsh"
+    ZDOTDIR=$(${zshWrapped}/bin/zsh -c "echo \$ZDOTDIR")
+  ${zshWrapped}/bin/zsh -c "source $ZDOTDIR/.zshenv; source $ZDOTDIR/.zshrc"
+  touch $out
+''


### PR DESCRIPTION
I added the check.nix, it just runs zsh .zshrc which only completes succesfully if there are no parse errors