### PR TITLE
modules/niri: implement hot-reloading

### DIFF
--- a/modules/niri/module.nix
+++ b/modules/niri/module.nix
@@ -308,6 +308,17 @@ in
     "share/applications/*.desktop"
     "share/systemd/user/niri.service"
   ];
+  config.patchHook = ''
+    chmod +w $out/share/systemd/user/niri.service
+    cat >> $out/share/systemd/user/niri.service<<EOF
+    [Unit]
+    X-Reload-Triggers=${config."config.kdl".path}
+    [Service]
+    ExecReload=$out/bin/niri msg action load-config-file --path ${config."config.kdl".path}
+    X-ReloadIfChanged=true
+    EOF
+  '';
+
   config.package = config.pkgs.niri;
   config.env = {
     NIRI_CONFIG = toString config."config.kdl".path;


### PR DESCRIPTION
This currently requires niri-git and there seems to be a bug in the switch-to-generation logic to actually trigger an automatic reload, but atleast manual works.