### PR TITLE
modules/bat: init

### DIFF
--- a/modules/bat/check.nix
+++ b/modules/bat/check.nix
@@ -1,0 +1,20 @@
+{
+  pkgs,
+  self,
+}:
+let
+  batWrapped =
+    (self.wrapperModules.bat.apply {
+      inherit pkgs;
+
+      "bat-config".content = ''
+        # Test config
+        --italic-text=never
+        --theme="Catppuccin Mocha"
+      '';
+    }).wrapper;
+in
+pkgs.runCommand "bat-test" { } ''
+  ${batWrapped}/bin/bat -p </dev/null
+  touch $out
+''

--- a/modules/bat/module.nix
+++ b/modules/bat/module.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  wlib,
+  ...
+}:
+{
+  _class = "wrapper";
+  options = {
+    "bat-config" = lib.mkOption {
+      type = wlib.types.file config.pkgs;
+      default.content = "";
+      description = "bat configuration file.";
+    };
+  };
+
+  config.env.BAT_CONFIG_PATH = toString config."bat-config".path;
+
+  config.package = config.pkgs.bat;
+  config.meta.maintainers = [ lib.maintainers.randomdude ];
+}


### PR DESCRIPTION
Add a module for `bat`, the `cat` clone with wings. 