### PR TITLE
Set meta.mainProgram for custom binName wrappers

### DIFF
--- a/checks/exe-path-bin-name.nix
+++ b/checks/exe-path-bin-name.nix
@@ -38,6 +38,13 @@ let
     };
   };
 
+  # Test 5: Custom binName updates meta.mainProgram
+  wrappedWithMeta = self.lib.wrapPackage {
+    inherit pkgs;
+    package = pkgs.hello;
+    binName = "hello-wrapped";
+  };
+
 in
 pkgs.runCommand "exe-path-bin-name-test" { } ''
   set -e
@@ -121,6 +128,15 @@ pkgs.runCommand "exe-path-bin-name-test" { } ''
     echo "PASS: Binary with flags executes correctly"
   else
     echo "FAIL: Binary with flags produced no output"
+    exit 1
+  fi
+
+  # Test 5: Custom binName updates meta.mainProgram
+  echo -e "\n=== Test 5: custom binName meta.mainProgram ==="
+  if [ "${wrappedWithMeta.meta.mainProgram}" = "hello-wrapped" ]; then
+    echo "PASS: meta.mainProgram follows custom binName"
+  else
+    echo "FAIL: meta.mainProgram should be 'hello-wrapped', got '${wrappedWithMeta.meta.mainProgram}'"
     exit 1
   fi
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -677,8 +677,11 @@ let
                   }
                 );
             };
-          # Pass through original attributes
-          meta = package.meta or { };
+          meta =
+            (package.meta or { })
+            // lib.optionalAttrs (binName != null) {
+              mainProgram = binName;
+            };
         }
         // lib.optionalAttrs (package ? version) {
           inherit (package) version;


### PR DESCRIPTION
When wrapPackage creates a wrapper with a custom `binName`, the resulting derivation still inherited `meta.mainProgram` from the base package. This made downstream consumers call the wrong executable unless they patched metadata with `overrideAttrs`.

Set `meta.mainProgram` to `binName` for wrapped packages, matching the generated wrapper executable.

Also adds a regression check covering custom `binName` metadata.

Validation:
- `nix build -L .#checks.$(nix eval --raw --impure --expr builtins.currentSystem).exe-path-bin-name`
- `nix flake check -L` evaluated checks and started running them, but timed out locally after 300s while executing the full suite.