### PR TITLE
ci: fix formatting check erroring out in an incorrect manner

### DIFF
--- a/checks/formatting.nix
+++ b/checks/formatting.nix
@@ -4,8 +4,11 @@
 }:
 
 pkgs.runCommand "formatting-check" { } ''
-  ${
-    pkgs.lib.getExe self.formatter.${pkgs.stdenv.hostPlatform.system}
-  } --no-cache --fail-on-change ${../.}
+  cp -r ${../.}/ src
+  # will be copied readonly from the /nix/store
+  # nixfmt sadly ignores --fail-on-change and still tries to write to the file
+  # ergo, we create our own writable copy
+  chmod -R +w src
+  ${pkgs.lib.getExe self.formatter.${pkgs.stdenv.hostPlatform.system}} --ci --tree-root ./src ./src
   touch $out
 ''


### PR DESCRIPTION
previously this would fail with a non descript openTempFileWithDefaultPermissions: permission denied (Permission denied)

now the correct file gets identified in the error log