### PR TITLE
ci: fix incorrect cache hits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,11 @@ jobs:
       - name: Setup Nix cache
         uses: nix-community/cache-nix-action@v7
         with:
-          primary-key: nix-${{ runner.os }}
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # don't keep caches from previous CI runs around. newest main should always be enough
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
 
       - name: Run checks
         run: nix flake check --log-format bar-with-logs


### PR DESCRIPTION
right now during the post phase we always hit the cache as the primary key is just the os instead of the revision. this causes newer cache artifacts to never be uploaded