### PR TITLE
fix fastfetch wrapper

### DIFF
--- a/modules/fastfetch/module.nix
+++ b/modules/fastfetch/module.nix
@@ -20,7 +20,7 @@ in
     };
     "config.jsonc" = lib.mkOption {
       type = wlib.types.file config.pkgs;
-      default.path = jsonFmt.generate "fastfetch-config" config.settings;
+      default.path = jsonFmt.generate "fastfetch-config.jsonc" config.settings;
       description = "fastfetch config file";
     };
   };


### PR DESCRIPTION
fastfetch claims it "couldnt find config" when no extension (.json or .jsonc) is on the config file, which stops this wrapper from working