### PR TITLE
modules/gh: init

### DIFF
--- a/modules/gh/check.nix
+++ b/modules/gh/check.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  self,
+}:
+let
+  ghWrapped =
+    (self.wrapperModules.gh.apply {
+      inherit pkgs;
+      settings = {
+        version = 1;
+        telemetry = "disabled";
+      };
+    }).wrapper;
+in
+pkgs.runCommand "gh-test" { nativeBuildInputs = [ ghWrapped ]; } ''
+  gh version | grep "${ghWrapped.version}"
+  gh config get telemetry | grep disabled
+  touch $out
+''

--- a/modules/gh/module.nix
+++ b/modules/gh/module.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  wlib,
+  ...
+}:
+let
+  yamlFmt = config.pkgs.formats.yaml { };
+in
+{
+  _class = "wrapper";
+
+  options = {
+    settings = lib.mkOption {
+      inherit (yamlFmt) type;
+      default = {
+        version = 1;
+      };
+      description = "See <https://cli.github.com/manual/gh_config>";
+      example = {
+        version = 1;
+        git_protocol = "ssh";
+        telemetry = "disabled";
+      };
+    };
+
+    extraFiles = lib.mkOption {
+      type = lib.types.attrsOf (wlib.types.file config.pkgs);
+      default = { };
+      description = "Additional files written to the configuration directory";
+      example = lib.literalExpression ''
+        {
+          "hosts.yml".content = builtins.toJSON {
+            "github.com".user = "<username>";
+          };
+        }
+      '';
+    };
+  };
+
+  config = {
+    package = lib.mkDefault config.pkgs.gh;
+
+    extraFiles."config.yml" = lib.mkIf (config.settings != null) {
+      path = yamlFmt.generate "config.yml" config.settings;
+    };
+
+    env.GH_CONFIG_DIR = toString (
+      config.pkgs.linkFarm "gh-merged-config" (
+        lib.mapAttrsToList (name: value: {
+          inherit name;
+          inherit (value) path;
+        }) config.extraFiles
+      )
+    );
+  };
+
+  meta.maintainers = [ lib.maintainers.bandithedoge ];
+}


### PR DESCRIPTION
I couldn't find a clean way to make gh load extensions from somewhere other than `$XDG_DATA_HOME/gh/extensions`.