### PR TITLE
hyprland: added lua support

### DIFF
--- a/modules/hyprland/check.nix
+++ b/modules/hyprland/check.nix
@@ -2,27 +2,27 @@
   pkgs,
   self,
 }:
-
 let
   hyprlandWrapped =
     (self.wrapperModules.hyprland.apply {
       inherit pkgs;
 
-      "hypr.conf".content = ''
+      "hyprland.lua".content = ''
+        hl.curve("easeOutQuint", { type = "bezier", points = { { 0.23, 1 }, { 0.32, 1 } } })
+        hl.curve("easeInOutCubic", { type = "bezier", points = { { 0.65, 0.05 }, { 0.36, 1 } } })
+        hl.curve("linear", { type = "bezier", points = { { 0, 0 }, { 1, 1 } } })
+        hl.curve("almostLinear", { type = "bezier", points = { { 0.5, 0.5 }, { 0.75, 1.0 } } })
+        hl.curve("quick", { type = "bezier", points = { { 0.15, 0 }, { 0.1, 1 } } })
+        hl.animation({
+            leaf = "global",
+            enabled = true,
+            speed = 10,
+            bezier = "default",
+        })
 
-        dwindle {
-          pseudotile = yes
-          preserve_split = yes
-          special_scale_factor = 0.95
-        }
-
-        general {
-          layout = dwindle
-        }
 
       '';
     }).wrapper;
-
 in
 pkgs.runCommand "hypr-test" { } ''
 

--- a/modules/hyprland/module.nix
+++ b/modules/hyprland/module.nix
@@ -7,18 +7,38 @@
 {
   _class = "wrapper";
   options = {
-    "hypr.conf" = lib.mkOption {
+    "hyprland.conf" = lib.mkOption {
       type = wlib.types.file config.pkgs;
       default.content = "";
       description = ''
-        for basic setup of one hypr.conf file
+        for basic setup of one hyprland.conf file
       '';
+    };
+
+    "hyprland.lua" = lib.mkOption {
+      type = wlib.types.file config.pkgs;
+      default.content = "";
+      description = ''
+        for basic setup of one hyprland.lua file in lua
+      '';
+    };
+
+    settings.configLang = lib.mkOption {
+      type = lib.types.string;
+      default.content = "hyprlang"; # Set it to hyprlang by default since people using this module were using that and I don't wanna break theiir config.
+      description = " can by set to lua if needed (recommmended)"; # hyprlang is about to be deprecated
     };
   };
 
-  config.flags = {
-    "--config" = config."hypr.conf".path;
-  };
+  config.flags =
+    let
+      cfg = config.settings;
+    in
+    {
+      "--config" = (
+        if config.configLang == "hyprlang" then cfg."hyprland.conf".path else cfg."hyprland.lua".path
+      );
+    };
 
   config.package = config.pkgs.hyprland;
 


### PR DESCRIPTION
Added an option to configure hyprland in lua instead. Right now, it still defaults to hyprlang since people using this module would be using that, but it is about to be deprecated, so. Also, i'll make a seperate PR for the systemd service.